### PR TITLE
Rate limit patch

### DIFF
--- a/src/components/market-indices.tsx
+++ b/src/components/market-indices.tsx
@@ -23,7 +23,7 @@ async function getMarketIndices() {
     const response = await fetch(
       "https://finance-query.onrender.com/v1/indices?region=US",
       {
-        next: { revalidate: 300 },
+        next: { revalidate: 900  },
       }
     );
     if (!response.ok) {

--- a/src/components/market-movers.tsx
+++ b/src/components/market-movers.tsx
@@ -62,8 +62,8 @@ export default function MarketMovers() {
 
     fetchMarketMovers();
 
-    // Optional: Set up polling to refresh data periodically
-    const intervalId = setInterval(fetchMarketMovers, 300000); // Refresh every 5 minutes
+  const FIFTEEN_MINUTES = 15 * 60 * 1000;
+  const intervalId = setInterval(fetchMarketMovers, FIFTEEN_MINUTES);
 
     return () => clearInterval(intervalId); // Clean up interval on unmount
   }, []);

--- a/src/components/market-news.tsx
+++ b/src/components/market-news.tsx
@@ -12,7 +12,7 @@ type NewsItem = {
 
 async function getFinanceNews() {
   try {
-    const response = await fetch("https://finance-query.onrender.com/v1/news", { next: { revalidate: 600 } })
+    const response = await fetch("https://finance-query.onrender.com/v1/news", { next: { revalidate: 900 } })
     if (!response.ok) {
       throw new Error("Failed to fetch news")
     }


### PR DESCRIPTION
This pull request makes adjustments to the revalidation intervals for fetching data and improves code readability by introducing a named constant for interval timing. These changes aim to standardize data refresh rates and make the code easier to understand.

### Changes to revalidation intervals:

* [`src/components/market-indices.tsx`](diffhunk://#diff-ba3506442767180f99bbd04865f89d42d097a8803a5b80611934d788fa05c56bL26-R26): Updated the `revalidate` property for market indices data from 300 seconds (5 minutes) to 900 seconds (15 minutes).
* [`src/components/market-news.tsx`](diffhunk://#diff-b8f9faa4d6e2716dff6475045edf2c73387dec574a452a263c4e6752689509e7L15-R15): Updated the `revalidate` property for finance news data from 600 seconds (10 minutes) to 900 seconds (15 minutes).

### Code readability improvement:

* [`src/components/market-movers.tsx`](diffhunk://#diff-de4f795c5fdd90ceb41f37ad29bc5607e835fb9be687d448bffebf92ee683202L65-R66): Replaced the hardcoded polling interval (5 minutes) with a named constant `FIFTEEN_MINUTES` to improve clarity and updated the interval to 15 minutes.